### PR TITLE
Achievable temperatures?

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Instead, join us in [Armchair Heavy Industries](https://discord.gg/armchairengin
 
 * 2 x 5015 axial (not blower) fan: 50x50x15mm
   * Suggested: [Delta AFB0524HHB](https://www.digikey.com/en/products/detail/delta-electronics/AFB0524HHB/2560406), $15 ea
+    * Sufficient to reach 80 - 85°C when using the heaters built-in thermostat
   * Optional: Any from this list from Digikey: [LIST](https://www.digikey.com/en/products/filter/dc-brushless-fans-bldc/217?s=N4IgjCBcpgLFoDGUBmBDANgZwKYBoQB7KAbXAFZyAmADggF0CAHAFyhAGUWAnASwDsA5iAC%2BBWADYEIZJHTZ8RUiFgAGCQE4A7A2ZtInHgOFjwGgMzTZ83AWKQy2jTRohGIVuy58hoguRoNK1RMWyUHcCoo8yl3TwNvYz8QLQ1VYLlQxXsyWDAJclV4OP1DHxMCMGcg6BkQhTtldPoRUyplQoBbToACdH43ESA)
   * Check your favorite ~~dealer~~ retailer to see if they have 5015 Axial (not blower) fans.
 


### PR DESCRIPTION
Hey! I've been running the heater for a while now, using the recommended Delta 50x50x15 fans using the 10mm spacers.

With my 220V 500W heater, this setup seems to be limited to 80°C - 90°C, depending on where in the chamber I measure.  
At that point, the two fans seem to reach their limit, unable to cool the PTC below ~170°C, and the built-in thermostat triggers regularly.

![image](https://github.com/user-attachments/assets/6e2dfdd9-13d8-4e91-b8f6-db0448edff3b)
(the temperature is measured by a M3 thermistor bolted into the side of the fins of the PTC. Chamber temps are 82°C at the back of the gantry, 86°C at the top-back of the printer, 87.1°C at the extruder and 87.7°C at the beacon coil)

Besides the thermostat, fans, and spacing between fans and deck panel, are there other factors in play here?  
If not, would it make sense to note that limitation in the README?

Personally, I'm now looking at some beefier fans to overcome this limitation. I think I'll keep the thermostat installed to prevent myself from accidentally melting the mount.